### PR TITLE
Add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "group:allNonMajor",
+    ":timezone(Asia/Tokyo)",
+    ":prHourlyLimitNone",
+    ":gomodTidy"
+  ],
+  "minimumReleaseAge": "7 days"
+}


### PR DESCRIPTION
- Configure minimumReleaseAge of 7 days to only update packages that have been released for at least one week
- Schedule updates to run at 9am Tokyo time on weekdays