### PR TITLE
chore(renovate): Docker イメージの digest pin と gomod patch の automerge

### DIFF
--- a/.github/workflows/ci-for-any-pr.yml
+++ b/.github/workflows/ci-for-any-pr.yml
@@ -21,6 +21,7 @@ jobs:
       go-code: ${{ steps.changes.outputs.go-code }}
       e2e-tests: ${{ steps.changes.outputs.e2e-tests }}
       helm-charts: ${{ steps.changes.outputs.helm-charts }}
+      renovate-config: ${{ steps.changes.outputs.renovate-config }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -61,6 +62,9 @@ jobs:
               - 'helm/**'
               - '.github/workflows/helm-ci.yml'
               - '.github/workflows/ci-for-any-pr.yml'
+            renovate-config:
+              - 'renovate.json'
+              - '.github/workflows/ci-for-any-pr.yml'
 
   ci-go:
     needs: detect-changes
@@ -86,9 +90,31 @@ jobs:
       helm-chart-path: helm/cargohold
       timeout-minutes: 10
 
+  renovate-config-ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: detect-changes
+    if: needs.detect-changes.outputs.renovate-config == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      # 引数でファイル名を渡すと global config として検証されてしまい、repo config
+      # 固有の検証が緩くなる。カレントディレクトリの renovate.json を自動検出させる。
+      # --strict は非推奨記法 (migration necessary) を warning ではなく失敗にする
+      - name: Validate renovate config
+        run: npx --yes --package renovate -c 'renovate-config-validator --strict'
+
   ci-summary:
     runs-on: ubuntu-latest
-    needs: [detect-changes, ci-go, e2e-tests, helm-ci]
+    needs: [detect-changes, ci-go, e2e-tests, helm-ci, renovate-config-ci]
     if: always()
     steps:
       - name: Check CI results
@@ -98,6 +124,7 @@ jobs:
           echo "  go-code: ${{ needs.detect-changes.outputs.go-code }}"
           echo "  e2e-tests: ${{ needs.detect-changes.outputs.e2e-tests }}"
           echo "  helm-charts: ${{ needs.detect-changes.outputs.helm-charts }}"
+          echo "  renovate-config: ${{ needs.detect-changes.outputs.renovate-config }}"
           echo ""
           echo "CI results:"
           if [ "${{ needs.detect-changes.outputs.go-code }}" == "true" ]; then
@@ -115,11 +142,17 @@ jobs:
           else
             echo "  helm-ci: skipped (no changes)"
           fi
+          if [ "${{ needs.detect-changes.outputs.renovate-config }}" == "true" ]; then
+            echo "  renovate-config-ci: ${{ needs.renovate-config-ci.result }}"
+          else
+            echo "  renovate-config-ci: skipped (no changes)"
+          fi
 
           if [ "${{ needs.detect-changes.result }}" == "failure" ] || \
              [ "${{ needs.ci-go.result }}" == "failure" ] || \
              [ "${{ needs.e2e-tests.result }}" == "failure" ] || \
-             [ "${{ needs.helm-ci.result }}" == "failure" ]; then
+             [ "${{ needs.helm-ci.result }}" == "failure" ] || \
+             [ "${{ needs.renovate-config-ci.result }}" == "failure" ]; then
             echo ""
             echo "One or more CI jobs failed"
             exit 1

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,11 @@
 	"labels": ["renovate"],
 	"packageRules": [
 		{
+			"description": "Docker イメージを digest pin する。floating tag (postgres:18-alpine, *:latest) は実体が drift しても差分が見えず、#56 では postgres:18-alpine の drift が e2e を壊した状態で気付けなかった。digest を固定して実体変化を PR として CI に通す",
+			"matchCategories": ["docker"],
+			"pinDigests": true
+		},
+		{
 			"matchUpdateTypes": ["major"],
 			"addLabels": ["major update"]
 		},
@@ -43,6 +48,18 @@
 			"matchManagers": ["github-actions"],
 			"matchUpdateTypes": ["major"],
 			"groupName": "GitHub Actions (Major)"
+		},
+		{
+			"description": "compose の dev/CI 用イメージは digest 更新の頻度が高い (latest タグを含む) ため 1 PR にまとめる。バージョン自体の更新は個別 PR のまま",
+			"matchManagers": ["docker-compose"],
+			"matchUpdateTypes": ["digest", "pinDigest"],
+			"groupName": "compose images (digest)"
+		},
+		{
+			"description": "Go 依存の patch は go-ci (fmt/vet/lint/race×3/coverage/build) と e2e が PR 上で検証するため automerge する。minimumReleaseAge 7 日のゲートも併せて効く",
+			"matchManagers": ["gomod"],
+			"matchUpdateTypes": ["patch"],
+			"automerge": true
 		}
 	],
 	"customManagers": [


### PR DESCRIPTION
#56 のフォローアップ。

## 1. Docker イメージの digest pin

`matchCategories: ["docker"]` に `pinDigests: true` を設定する。

#56 で `postgres:18-alpine` の実体が drift して e2e が壊れていたが、tag が変わらないため差分としては一切見えず、`compose.yml` を触る変更が発生するまで誰も気付けない状態だった。digest を固定すれば実体の変化が Renovate の PR として上がり、CI を通ってからマージされる。

対象は Dockerfile 群 (`golang`, `alpine`) と compose の `postgres:18-alpine` / `redis:8-alpine` / `nginx:alpine` / `chrislusf/seaweedfs:latest` / `amazon/aws-cli:latest`。特に後者 2 つは `latest` なので現状まったく追跡できていない。

初回は Renovate が digest を付与する pin PR を 1 本出す。

### 粒度への配慮

compose の digest 更新は頻度が高いため 1 PR にまとめる。バージョン自体の更新は従来どおり個別 PR のまま。

```json
{
  "matchManagers": ["docker-compose"],
  "matchUpdateTypes": ["digest", "pinDigest"],
  "groupName": "compose images (digest)"
}
```

## 2. gomod patch の automerge

#56 で保留にしていたもの。Go 依存の patch を automerge する。

根拠:

- go-ci が fmt / vet / lint / race ×3 / coverage / build を、e2e が結合動作を PR 上で検証する
- `minimumReleaseAge: 7 days` のゲートが併せて効く
- `main` は protected で required status checks があるため、GitHub の auto-merge は CI 通過まで待つ (#56 で auto-merge が e2e 完了まで待ってからマージされたことで確認済み)

なお merge されると CD が動きイメージが build & push される点は #56 で述べたとおり。patch のみを対象とし、minor 以上は従来どおり手動レビューになる。

## 検証

`renovate-config-validator` を repo config として実行し `Config validated successfully`。migration warning なし。

`docker: { "pinDigests": true }` という書き方は Renovate に `matchCategories` の packageRule へ migrate される非推奨形だったため、最初から移行後の形で記述している。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdCmKvgeoQVCReRchvafjd)_